### PR TITLE
Allow filtering the list of assets with a regular expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,11 @@ Usage:
   ghdl <user/repo[#tagname]> [flags]
 
 Flags:
-  -F, --filter-off    turn off auto-filtering feature
-  -h, --help          help for ghdl
-  -n, --name string   specify binary file name to enhance filtering and extracting accuracy
-  -p, --path path     save binary to path and add execute permission to it (default ".")
+  -f, --asset-filter string   specify regular expression for the asset name; used in conjunction with the platform and architecture filters.
+  -F, --filter-off            turn off auto-filtering feature
+  -h, --help                  help for ghdl
+  -n, --name string           specify binary file name to enhance filtering and extracting accuracy
+  -p, --path path             save binary to path and add execute permission to it (default ".")
 ```
 
 It's tedious to specify `-p` manually, we can alias `ghdl -p "$DirInPath"` to a shorthand command, then use it as a executable installer.

--- a/ghdl/main.go
+++ b/ghdl/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/beetcb/ghdl"
@@ -32,9 +33,21 @@ ghdl handles archived or compressed file as well`,
 		if err != nil {
 			panic(err)
 		}
+		assetFilterString, err := cmdFlags.GetString("asset-filter")
+		if err != nil {
+			panic(err)
+		}
+		var assetFilter *regexp.Regexp
+		if assetFilterString != "" {
+			assetFilter, err = regexp.Compile(assetFilterString)
+			if err != nil {
+				panic(err)
+			}
+		}
+
 		repo, tag := parseArg(args[0])
 		ghRelease := ghdl.GHRelease{RepoPath: repo, TagName: tag}
-		ghReleaseDl, err := ghRelease.GetGHReleases(filterOff)
+		ghReleaseDl, err := ghRelease.GetGHReleases(filterOff, assetFilter)
 
 		if err != nil {
 			h.Println(fmt.Sprintf("get gh releases failed: %s", err), h.PrintModeErr)
@@ -78,6 +91,8 @@ func main() {
 
 func init() {
 	rootCmd.PersistentFlags().StringP("name", "n", "", "specify binary file name to enhance filtering and extracting accuracy")
+	rootCmd.PersistentFlags().StringP("asset-filter", "f", "",
+		"specify regular expression for the asset name; used in conjunction with the platform and architecture filters.")
 	rootCmd.PersistentFlags().StringP("path", "p", ".", "save binary to `path` and add execute permission to it")
 	rootCmd.PersistentFlags().BoolP("filter-off", "F", false, "turn off auto-filtering feature")
 }

--- a/ghdl_test.go
+++ b/ghdl_test.go
@@ -12,7 +12,7 @@ import (
 // Shall never failed (if complied) but can test TUI behavior and functionality
 func TestDownloadFdBinary(t *testing.T) {
 	ghRelease := GHRelease{RepoPath: "sharkdp/fd"}
-	ghReleaseDl, err := ghRelease.GetGHReleases(false)
+	ghReleaseDl, err := ghRelease.GetGHReleases(false, nil)
 
 	if err != nil {
 		h.Println(fmt.Sprintf("get gh releases failed: %s", err), h.PrintModeErr)


### PR DESCRIPTION
## What this PR fixes
Thanks for this nice tool. While playing with it (I wanted to download assets of [golangci-lint](https://github.com/golangci/golangci-lint/releases/tag/v1.47.2), which includes a variery of formats like Debian packages or `tar.gz`  archives for each platform), I wanted to limit the asset list displayed to certain files. In some cases, I knew I wanted to explicitly download `*.tar.gz` files, but could not find a simple way to filter the assets list further.

This PR introduces a new '--asset-filter' flag, which is a regexp that is applied against the asset list (right after the OS and Arch filters are applied). If users know exactly which kind of asset they want to download, this might help skip the interactive listing and download the right asset instead.

Since this is my very first PR in this repo, please do let me know if things ought to be done differently.